### PR TITLE
修改获取内网ip方式，修复登陆失败问题

### DIFF
--- a/cqupt.py
+++ b/cqupt.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 from base64 import b64decode
 from getpass import getpass
 from urllib.request import urlopen, Request
-from socket import socket, AF_INET, SOCK_DGRAM
+import socket
 
 import os
 import sys
@@ -42,9 +42,7 @@ def get_uac_passwd(args) -> str:
 def get_ipv4a(args) -> str:
     if args.ipv4 != 'auto':
         return args.ipv4
-    with socket(AF_INET, SOCK_DGRAM) as sock:
-        sock.connect(('223.5.5.5', 80))
-        return sock.getsockname()[0]
+    return socket.gethostbyname(socket.gethostname())
 
 
 def get_maca(args) -> str:


### PR DESCRIPTION
校园网登陆字段：`wlan_user_ip=10.17.32.107`
原来通过生成UDP包，然后从中获取的ip为：`wlan_user_ip=198.18.0.1`
导致返回
```
[INFO ] Sign in as 168xxxx@cmcc 198.18.0.1(000000000000) linux-firefox ...
[INFO ] Attempt (1/3): {"result":"0","msg":"","ret_code":1}
[INFO ] Attempt (2/3): {"result":"0","msg":"","ret_code":1}
[INFO ] Attempt (3/3): {"result":"0","msg":"","ret_code":1}
```
所以改用通过主机名获取内网ip为：`wlan_user_ip=10.17.32.107`
符合登陆预期
```
[INFO ] Sign in as 168xxxx@cmcc 10.17.32.107(000000000000) linux-firefox ...
[INFO ] Attempt (1/3): {"result":"1","msg":"\u8ba4\u8bc1\u6210\u529f"}
[INFO ] Attempt (2/3): {"result":"0","msg":"","ret_code":2}
[INFO ] Succeed. Have fun :)
```