### PR TITLE
feat: 从网页获取wlan ip

### DIFF
--- a/cqupt.py
+++ b/cqupt.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from base64 import b64decode
 from getpass import getpass
+import re
 from urllib.request import urlopen, Request
 import socket
 import os
@@ -9,65 +10,88 @@ import json
 import time
 import logging
 
-HOST = '192.168.200.2:801'
-REFERER = 'http://192.168.200.2/'
-PORTAL = 'http://192.168.200.2:801/eportal'
+HOST = "192.168.200.2:801"
+REFERER = "http://192.168.200.2/"
+PORTAL = "http://192.168.200.2:801/eportal"
 
 AGENTS = {
-    'android-chrome': 'Mozilla/5.0 (Linux; Android 12; Pixel 6 Build/SD1A.210817.023; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/94.0.4606.71 Mobile Safari/537.36',
-    'ios-safari': 'Mozilla/5.0 (iPhone13,2; U; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/15E148 Safari/602.1',
-    'windows-edge': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
-    'macos-safari': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9',
-    'linux-firefox': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1',
+    "android-chrome": "Mozilla/5.0 (Linux; Android 12; Pixel 6 Build/SD1A.210817.023; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/94.0.4606.71 Mobile Safari/537.36",
+    "ios-safari": "Mozilla/5.0 (iPhone13,2; U; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/15E148 Safari/602.1",
+    "windows-edge": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246",
+    "macos-safari": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9",
+    "linux-firefox": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1",
 }
 
-ISP = ('cmcc', 'telecom', 'unicom', 'xyw')
+ISP = ("cmcc", "telecom", "unicom", "xyw")
 
 
 def get_uac_passwd(args) -> str:
-    passwd = os.getenv('CQUPT_UAC_PASSWORD')
+    passwd = os.getenv("CQUPT_UAC_PASSWORD")
     if passwd:
         return passwd
 
     if not sys.stdin.isatty():
-        return sys.stdin.readline().strip('\n')
+        return sys.stdin.readline().strip("\n")
 
     if args.passwd:
         return args.passwd
 
-    return getpass(f'[cqupt] password for {args.account}: ')
+    return getpass(f"[cqupt] password for {args.account}: ")
 
 
-def get_ipv4a(args) -> str:
-    if args.ipv4 != 'auto':
+def get_ipv4a(args) -> list[str]:
+    if args.ipv4 != "auto":
         return [args.ipv4]
     return socket.gethostbyname_ex(socket.gethostname())[2]
 
 
 def get_maca(args) -> str:
-    return args.mac.replace(':', '').replace('-', '').lower()
+    return args.mac.replace(":", "").replace("-", "").lower()
 
 
 def get_ua(args) -> str:
     if not args.ua in AGENTS:
-        raise KeyError(f'invalid user agent: {args.ua}')
+        raise KeyError(f"invalid user agent: {args.ua}")
     return AGENTS[args.ua]
 
 
 def get_isp(args) -> str:
     if not args.isp in ISP:
-        raise KeyError(f'invalid ISP name: {args.isp}')
+        raise KeyError(f"invalid ISP name: {args.isp}")
     return args.isp
 
 
 def try_decode(s: str) -> str:
     try:
-        if s.startswith('\\u'):
-            return bytes(s, 'utf-8').decode('unicode_escape')
+        if s.startswith("\\u"):
+            return bytes(s, "utf-8").decode("unicode_escape")
         else:
             return b64decode(s).decode()
     except:
         return s
+
+def extract(varname, html: str) -> str:
+    m = re.search(rf"{varname}\s*=\s*['\"]([^'\"]+)['\"]", html)
+    return m.group(1) if m else None
+
+def get_wlan_ip(login_url: str) -> str:
+    req = Request(login_url)
+    with urlopen(req, timeout=5) as resp:
+        raw = resp.read()
+        charset = resp.headers.get_content_charset() or "gb2312"
+        html = raw.decode(charset, errors="ignore")
+    for name in ("v46ip", "ss5", "v4ip"):
+        val = extract(name, html)
+        if val:
+            return val
+    hex3 = extract("ss3")
+    if hex3:
+        if len(hex3) % 2:
+            hex3 = "0" + hex3
+        parts = [str(int(hex3[i : i + 2], 16)) for i in range(0, len(hex3), 2)]
+        return ".".join(parts)
+
+    return None
 
 
 def connect(
@@ -81,80 +105,83 @@ def connect(
     maca = get_maca(args)
     agent = get_ua(args)
 
-    logging.info(f'正在尝试以 {account}@{isp} {ipv4a}({maca}) {args.ua} 登录...')
+    logging.info(f"正在尝试以 {account}@{isp} {ipv4a}({maca}) {args.ua} 登录...")
 
-    url = f'{PORTAL}?c=Portal&a=login&callback=dr1003&login_method=1&wlan_user_ip={ipv4a}&wlan_user_mac={maca}&user_account=,0,{account}@{isp}&user_password={passwd}&jsVersion=3.3.3'
+    url = f"{PORTAL}?c=Portal&a=login&callback=dr1003&login_method=1&wlan_user_ip={ipv4a}&wlan_user_mac={maca}&user_account=,0,{account}@{isp}&user_password={passwd}&jsVersion=3.3.3"
     req = Request(url)
-    req.add_header('Host', HOST)
-    req.add_header('Referer', REFERER)
-    req.add_header('User-Agent', agent)
+    req.add_header("Host", HOST)
+    req.add_header("Referer", REFERER)
+    req.add_header("User-Agent", agent)
 
     for i in range(attempt):
         with urlopen(req) as res:
             res_raw = res.read().decode()[7:-1]
             res_dict = json.loads(res_raw)
-            logging.info(f'Attempt ({i+1}/{attempt})')
-            if res_dict['result'] == '1' and try_decode(res_dict['msg'] == '认证成功'):
-                logging.info(f'Succeed. Have fun :)')
+            logging.info(f"Attempt ({i+1}/{attempt})")
+            if res_dict["result"] == "1" and try_decode(res_dict["msg"] == "认证成功"):
+                logging.info(f"Succeed. Have fun :)")
                 return True
-            elif res_dict['result'] == '0':
-                code = res_dict['ret_code']
-                msg_raw = res_dict['msg']
+            elif res_dict["result"] == "0":
+                code = res_dict["ret_code"]
+                msg_raw = res_dict["msg"]
                 if code == 1:
-                    msg = '错误的内网ip' if msg_raw == '' else try_decode(msg_raw)
+                    msg = "错误的内网ip" if msg_raw == "" else try_decode(msg_raw)
                     logging.info(msg)
-                    logging.info('切换内网ip，再次尝试登录')
+                    logging.info("切换内网ip，再次尝试登录")
                     return False
                 elif code == 2:
-                    logging.info('您已经登录')
+                    logging.info("您已经登录")
                     return True
                 else:
-                    logging.info('未知错误')
+                    logging.info("未知错误")
             time.sleep(1.0)
     return False
 
 
 def run(args) -> bool:
     ipv4a_list = get_ipv4a(args)
+    wlan_ip = get_wlan_ip(REFERER)
+    if wlan_ip:
+        ipv4a_list.insert(0, wlan_ip)
     for ipv4a in ipv4a_list:
         if connect(args, ipv4a):
             return True
     return False
 
 
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO, format='[%(levelname)-5s] %(message)s')
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)-5s] %(message)s")
 
-    parser = ArgumentParser(description='[cqupt] 0.0.1')
-    parser.add_argument('account', help='specify your unified authentication code')
+    parser = ArgumentParser(description="[cqupt] 0.0.1")
+    parser.add_argument("account", help="specify your unified authentication code")
     parser.add_argument(
-        '--isp',
-        dest='isp',
-        default='cmcc',
-        help='specify your ISP, choose `cmcc` for China Mobile, `telecom` for China Telecom, `unicom` for Chine Unicom and `xyw` if you are a teacher (default: cmcc)',
+        "--isp",
+        dest="isp",
+        default="cmcc",
+        help="specify your ISP, choose `cmcc` for China Mobile, `telecom` for China Telecom, `unicom` for Chine Unicom and `xyw` if you are a teacher (default: cmcc)",
     )
     parser.add_argument(
-        '--ipv4-addr',
-        dest='ipv4',
-        default='auto',
-        help='specify a local IPv4 address (default: auto)',
+        "--ipv4-addr",
+        dest="ipv4",
+        default="auto",
+        help="specify a local IPv4 address (default: auto)",
     )
     parser.add_argument(
-        '--mac-addr',
-        dest='mac',
-        default='00:00:00:00:00:00',
-        help='specify a physical address (default: 00:00:00:00:00:00)',
+        "--mac-addr",
+        dest="mac",
+        default="00:00:00:00:00:00",
+        help="specify a physical address (default: 00:00:00:00:00:00)",
     )
     parser.add_argument(
-        '--user-agent',
-        dest='ua',
-        default='linux-firefox',
-        help='specify a user agent, available options are: android-chrome, ios-safari, macos-safari, windows-edge, linux-firefox (default: linux-firefox)',
+        "--user-agent",
+        dest="ua",
+        default="linux-firefox",
+        help="specify a user agent, available options are: android-chrome, ios-safari, macos-safari, windows-edge, linux-firefox (default: linux-firefox)",
     )
     parser.add_argument(
-        '--force-password',
-        dest='passwd',
-        help='specify your UAC password implicitly (not recommended)',
+        "--force-password",
+        dest="passwd",
+        help="specify your UAC password implicitly (not recommended)",
     )
     args = parser.parse_args()
 

--- a/cqupt.py
+++ b/cqupt.py
@@ -1,8 +1,8 @@
 from argparse import ArgumentParser
 from base64 import b64decode
 from getpass import getpass
-import re
 from urllib.request import urlopen, Request
+import re
 import socket
 import os
 import sys
@@ -70,7 +70,7 @@ def try_decode(s: str) -> str:
     except:
         return s
 
-def extract(varname, html: str) -> str:
+def extract(varname: str, html: str) -> str:
     m = re.search(rf"{varname}\s*=\s*['\"]([^'\"]+)['\"]", html)
     return m.group(1) if m else None
 


### PR DESCRIPTION
当使用热点或者路由器连接校园网时，此时与校园网交互的对象为手机或者路由器，此时wlan ip无法从本机获取，因为本机对于校园网来说是不可见的。

但是此情况依然可以用登录页登陆，因此登录页的wlan ip并非从本设备获取。观察登录页登陆流程可以得到，AC会在访问登录页时内嵌设备信息在html中，因此可以通过解析内嵌在html中的信息直接获取AC侧实际的wlan ip，而不用从本地设备中寻找。

理论上不论是直连校园网还是连接中继校园网的设备，都可以通过此方法获取准确的wlan ip。但是依然保留从本地获取内网ip的方法作为fallback。